### PR TITLE
Issue/10 ページネーションの実装

### DIFF
--- a/src/features/Pagenation/Button/index.module.css
+++ b/src/features/Pagenation/Button/index.module.css
@@ -1,0 +1,46 @@
+/* 共通のボタン */
+.nav-btn,
+.page-btn {
+  height: 48px;
+  min-width: 48px;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: 1px solid #f0f0f0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  user-select: none;
+  transition: all 0.2s ease;
+}
+
+.nav-btn.disabled,
+.nav-btn[disabled],
+.page-btn[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.page-btn {
+  min-width: 48px;
+  padding: 0 14px;
+}
+
+.page-btn:hover:not(.page-btn--active):not([disabled]) {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.06);
+}
+
+.page-btn--active {
+  background: #f6b000; /* 黄色 */
+  color: #000;
+  font-weight: 600;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+}
+
+.nav-btn {
+  min-width: 40px;
+  padding: 0 8px;
+}

--- a/src/features/Pagenation/Button/index.tsx
+++ b/src/features/Pagenation/Button/index.tsx
@@ -1,0 +1,44 @@
+import styles from "./index.module.css";
+
+type ButtonVariant = "nav" | "page" | "dots";
+
+interface ButtonProps {
+  variant?: ButtonVariant;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+  ariaLabel?: string;
+}
+
+export const Button = ({
+  variant = "page",
+  active = false,
+  disabled = false,
+  onClick,
+  children,
+  ariaLabel,
+}: ButtonProps) => {
+  const getClassName = () => {
+    const baseClass = styles[`${variant}-btn`];
+    if (variant === "page" && active) {
+      return `${baseClass} ${styles["page-btn--active"]}`;
+    }
+    if (disabled) {
+      return `${baseClass} ${styles.disabled}`;
+    }
+    return baseClass;
+  };
+
+  return (
+    <button
+      type="button"
+      className={getClassName()}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+};

--- a/src/features/Pagenation/PageDropdown/index.module.css
+++ b/src/features/Pagenation/PageDropdown/index.module.css
@@ -1,0 +1,132 @@
+.container {
+  position: relative;
+  display: inline-block;
+}
+
+.trigger {
+  height: 48px;
+  min-width: 48px;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: bold;
+  user-select: none;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #000;
+}
+
+.trigger:hover {
+  background: #f8f8f8;
+  color: #666;
+}
+
+.trigger[aria-expanded="true"] {
+  background: #f0f0f0;
+  color: #000;
+}
+
+.dropdown {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  min-width: 100px;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+.scrollContainer {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+/* カスタムスクロールバー */
+.scrollContainer::-webkit-scrollbar {
+  width: 8px;
+}
+
+.scrollContainer::-webkit-scrollbar-track {
+  background: #f5f5f5;
+  border-radius: 4px;
+}
+
+.scrollContainer::-webkit-scrollbar-thumb {
+  background: #d0d0d0;
+  border-radius: 4px;
+}
+
+.scrollContainer::-webkit-scrollbar-thumb:hover {
+  background: #b0b0b0;
+}
+
+.item {
+  display: block;
+  width: 100%;
+  padding: 12px 20px;
+  border: none;
+  background: none;
+  text-align: center;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.15s ease;
+  border-radius: 8px;
+  color: #333;
+}
+
+.item:hover {
+  background: #f8f8f8;
+}
+
+.itemActive {
+  background: #f6b000;
+  color: #000;
+}
+
+.itemActive:hover {
+  background: #f6b000;
+}
+
+/* レスポンシブ */
+@media (max-width: 768px) {
+  .trigger {
+    height: 40px;
+    min-width: 40px;
+    padding: 0 10px;
+  }
+
+  .dropdown {
+    min-width: 80px;
+  }
+
+  .scrollContainer {
+    max-height: 200px;
+  }
+
+  .item {
+    padding: 10px 16px;
+    font-size: 13px;
+  }
+}

--- a/src/features/Pagenation/PageDropdown/index.module.css
+++ b/src/features/Pagenation/PageDropdown/index.module.css
@@ -19,6 +19,7 @@
   align-items: center;
   justify-content: center;
   color: #000;
+  white-space: nowrap;
 }
 
 .trigger:hover {
@@ -57,7 +58,7 @@
 }
 
 .scrollContainer {
-  max-height: 280px;
+  max-height: 150px;
   overflow-y: auto;
   padding: 8px;
 }
@@ -107,26 +108,4 @@
 
 .itemActive:hover {
   background: #f6b000;
-}
-
-/* レスポンシブ */
-@media (max-width: 768px) {
-  .trigger {
-    height: 40px;
-    min-width: 40px;
-    padding: 0 10px;
-  }
-
-  .dropdown {
-    min-width: 80px;
-  }
-
-  .scrollContainer {
-    max-height: 200px;
-  }
-
-  .item {
-    padding: 10px 16px;
-    font-size: 13px;
-  }
 }

--- a/src/features/Pagenation/PageDropdown/index.tsx
+++ b/src/features/Pagenation/PageDropdown/index.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from "react";
+
+import styles from "./index.module.css";
+
+interface PageDropdownProps {
+  hiddenPages: number[];
+  onPageSelect: (page: number) => void;
+  currentPage: number;
+}
+
+export const PageDropdown = ({
+  hiddenPages,
+  onPageSelect,
+  currentPage,
+}: PageDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 外側クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const handlePageClick = (page: number) => {
+    onPageSelect(page);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={styles.container} ref={dropdownRef}>
+      <button
+        type="button"
+        className={styles.trigger}
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="隠れたページを表示"
+        aria-expanded={isOpen}
+      >
+        • • •
+      </button>
+
+      {isOpen && (
+        <div className={styles.dropdown} role="menu">
+          <div className={styles.scrollContainer}>
+            {hiddenPages.map((page) => (
+              <button
+                key={page}
+                type="button"
+                className={`${styles.item} ${
+                  page === currentPage ? styles.itemActive : ""
+                }`}
+                onClick={() => handlePageClick(page)}
+                role="menuitem"
+                aria-label={`ページ ${page}`}
+              >
+                {page}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/Pagenation/index.module.css
+++ b/src/features/Pagenation/index.module.css
@@ -1,0 +1,16 @@
+
+/* Pagination wrapper */
+.pagination-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: transparent;
+  padding: 30px;
+}
+
+/* ページ番号の nav */
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}

--- a/src/features/Pagenation/index.tsx
+++ b/src/features/Pagenation/index.tsx
@@ -1,0 +1,148 @@
+import { Button } from "./Button";
+import styles from "./index.module.css";
+import { PageDropdown } from "./PageDropdown";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  maxVisiblePages?: number;
+}
+
+type PageItem =
+  | { type: "page"; value: number }
+  | { type: "dots"; hiddenPages: number[] };
+
+export const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  maxVisiblePages = 3,
+}: PaginationProps) => {
+  // ページ番号の配列を生成
+  const getPageNumbers = (): PageItem[] => {
+    const pages: PageItem[] = [];
+
+    if (totalPages <= maxVisiblePages) {
+      // 全ページを表示
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push({ type: "page", value: i });
+      }
+    } else {
+      // 省略表示を含むページ番号を生成
+      const halfVisible = Math.floor(maxVisiblePages / 2);
+      let startPage = Math.max(1, currentPage - halfVisible);
+      let endPage = Math.min(totalPages, currentPage + halfVisible);
+
+      // 開始ページの調整
+      if (currentPage <= halfVisible) {
+        endPage = maxVisiblePages;
+      }
+      // 終了ページの調整
+      if (currentPage + halfVisible >= totalPages) {
+        startPage = totalPages - maxVisiblePages + 1;
+      }
+
+      // 最初のページ
+      if (startPage > 1) {
+        pages.push({ type: "page", value: 1 });
+        if (startPage > 2) {
+          // 隠れたページ番号を計算
+          const hiddenPages = Array.from(
+            { length: startPage - 2 },
+            (_, i) => i + 2,
+          );
+          pages.push({ type: "dots", hiddenPages });
+        }
+      }
+
+      // 中間のページ
+      for (let i = startPage; i <= endPage; i++) {
+        pages.push({ type: "page", value: i });
+      }
+
+      // 最後のページ
+      if (endPage < totalPages) {
+        if (endPage < totalPages - 1) {
+          // 隠れたページ番号を計算
+          const hiddenPages = Array.from(
+            { length: totalPages - endPage - 1 },
+            (_, i) => endPage + i + 1,
+          );
+          pages.push({ type: "dots", hiddenPages });
+        }
+        pages.push({ type: "page", value: totalPages });
+      }
+    }
+
+    return pages;
+  };
+
+  const handlePrevious = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPages) {
+      onPageChange(currentPage + 1);
+    }
+  };
+
+  const pageNumbers = getPageNumbers();
+
+  return (
+    <div className={styles["pagination-wrapper"]}>
+      {/* 前へボタン */}
+      <Button
+        variant="nav"
+        disabled={currentPage === 1}
+        onClick={handlePrevious}
+        ariaLabel="前のページ"
+      >
+        ＜
+      </Button>
+
+      {/* ページ番号 */}
+      <nav className={styles.pagination} aria-label="ページネーション">
+        {pageNumbers.map((item) => {
+          if (item.type === "dots") {
+            // 隠れたページの範囲から一意なキーを生成
+            const key = `dots-${item.hiddenPages[0]}-${item.hiddenPages[item.hiddenPages.length - 1]}`;
+            return (
+              <PageDropdown
+                key={key}
+                hiddenPages={item.hiddenPages}
+                onPageSelect={onPageChange}
+                currentPage={currentPage}
+              />
+            );
+          }
+
+          return (
+            <Button
+              key={item.value}
+              variant="page"
+              active={item.value === currentPage}
+              onClick={() => onPageChange(item.value)}
+              ariaLabel={`ページ ${item.value}`}
+            >
+              {item.value}
+            </Button>
+          );
+        })}
+      </nav>
+
+      {/* 次へボタン */}
+      <Button
+        variant="nav"
+        disabled={currentPage === totalPages}
+        onClick={handleNext}
+        ariaLabel="次のページ"
+      >
+        ＞
+      </Button>
+    </div>
+  );
+};

--- a/src/features/WorkIndex/hook/useWorks.tsx
+++ b/src/features/WorkIndex/hook/useWorks.tsx
@@ -2,15 +2,47 @@ import useSWR from "swr";
 
 import { fetchData } from "@/util/fetchData";
 
-import type { Work } from "@/shared/types/work";
+import type { Work, WorkListResponse } from "@/shared/types/work";
 
-const useWorks = () => {
-  const fetcher = async (url: string): Promise<Work[]> => {
+interface UseWorksParams {
+  page?: number;
+  limit?: number;
+}
+
+interface UseWorksReturn {
+  data: Work[] | undefined;
+  totalCount: number;
+  currentPage: number;
+  limit: number;
+  error: Error | undefined;
+  isLoading: boolean;
+}
+
+const useWorks = ({
+  page = 1,
+  limit = 20,
+}: UseWorksParams = {}): UseWorksReturn => {
+  const url = `/works?page=${page}&limit=${limit}`;
+
+  const fetcher = async (url: string): Promise<WorkListResponse> => {
     const response = await fetchData(url);
-    return response.works;
+    return response;
   };
-  const { data, error, isLoading } = useSWR<Work[]>("/works", fetcher);
-  return { data, error, isLoading };
+
+  const {
+    data: response,
+    error,
+    isLoading,
+  } = useSWR<WorkListResponse>(url, fetcher);
+
+  return {
+    data: response?.works,
+    totalCount: response?.total_count ?? 0,
+    currentPage: response?.page ?? page,
+    limit: response?.limit ?? limit,
+    error,
+    isLoading,
+  };
 };
 
 export default useWorks;

--- a/src/features/WorkIndex/index.tsx
+++ b/src/features/WorkIndex/index.tsx
@@ -1,10 +1,28 @@
+import { useSearchParams } from "react-router-dom";
+
 import useWorks from "./hook/useWorks";
 import styles from "./index.module.css";
 
+import { Pagination } from "@/features/Pagenation";
 import Card from "@/shared/ui/Card";
 
+const ITEMS_PER_PAGE = 20;
+
 const WorkIndex = () => {
-  const { data, error, isLoading } = useWorks();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Number(searchParams.get("page")) || 1;
+
+  const { data, totalCount, error, isLoading } = useWorks({
+    page: currentPage,
+    limit: ITEMS_PER_PAGE,
+  });
+
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+
+  const handlePageChange = (page: number) => {
+    setSearchParams({ page: String(page) });
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   if (isLoading) {
     return (
@@ -23,25 +41,34 @@ const WorkIndex = () => {
   }
 
   return (
-    <div className={styles["works-index"]}>
-      {data.map((work) => (
-        <Card
-          key={work.id}
-          title={
-            work.title.length > 14
-              ? `${work.title.slice(0, 14)}...`
-              : work.title
-          }
-          tags={["test", "mock"]}
-          imageURL={
-            work.assets[0].asset_type === "image"
-              ? work.assets[0].url
-              : undefined
-          }
-          postDate={new Date(work.created_at.split(" ")[0])}
+    <>
+      <div className={styles["works-index"]}>
+        {data.map((work) => (
+          <Card
+            key={work.id}
+            title={
+              work.title.length > 14
+                ? `${work.title.slice(0, 14)}...`
+                : work.title
+            }
+            tags={["test", "mock"]}
+            imageURL={
+              work.assets[0].asset_type === "image"
+                ? work.assets[0].url
+                : undefined
+            }
+            postDate={new Date(work.created_at.split(" ")[0])}
+          />
+        ))}
+      </div>
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
         />
-      ))}
-    </div>
+      )}
+    </>
   );
 };
 

--- a/src/shared/types/work.ts
+++ b/src/shared/types/work.ts
@@ -20,4 +20,11 @@ type Asset = {
   work_id: string;
 };
 
-export type { Work };
+type WorkListResponse = {
+  works: Work[];
+  total_count: number;
+  page: number;
+  limit: number;
+};
+
+export type { Work, WorkListResponse };


### PR DESCRIPTION
 pagenationについて
ページネーションのUIをできるだけfigmaに寄せました
使い方は見た目と同じだが（・・・）の部分をボタンとして配置してドロップダウンとして間のページを表示できるようにした。（独断なので消しても良い）
作品一覧にURLベースのページネーション機能を実装して/?page=2でpageを指定できるようにしたなにもない場合はpage=1
limitは/home/user/workspace/toybox/toybox-front/src/features/WorkIndex/index.tsx のconst ITEMS_PER_PAGE = 20;でとりあえず指定している
- WorkListResponse型を追加してAPI応答の型安全性を向上
- useWorksフックをページネーション対応に拡張（page/limit引数）
- WorkIndexでuseSearchParamsを使用してURL状態管理
- Paginationコンポーネントを統合
- ページ切り替え時に自動的にページ最上部に
