### PR TITLE
feat: サムネイルアップロードコンポーネントuiの作成#37

### DIFF
--- a/src/features/WorkForm/ImageUpload/index.module.css
+++ b/src/features/WorkForm/ImageUpload/index.module.css
@@ -1,0 +1,53 @@
+.upload-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.upload-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--font-color);
+}
+
+.upload-area {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 5px dashed var(--primary-color);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  background: #fff;
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+
+  &:hover {
+    border-color: var(--primary-color);
+    background: rgba(251, 191, 36, 0.05);
+  }
+
+  &[data-has-image="true"] {
+    border-style: solid;
+    border-color: var(--border-color);
+
+    &:hover {
+      border-color: var(--primary-color);
+    }
+  }
+}
+
+.file-input {
+  display: none;
+}
+
+.preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}

--- a/src/features/WorkForm/ImageUpload/index.tsx
+++ b/src/features/WorkForm/ImageUpload/index.tsx
@@ -1,0 +1,122 @@
+import { useRef, useState } from "react";
+import CloudUploadRoundedIcon from "@mui/icons-material/CloudUploadRounded";
+
+import styles from "./index.module.css";
+
+type ImageUploadProps = {
+  label?: string;
+  onImageSelect: (file: File) => void;
+  acceptedFormats?: string;
+  maxSizeMB?: number;
+  previewUrl?: string;
+};
+
+const ImageUpload = ({
+  onImageSelect,
+  acceptedFormats = "image/png, image/jpeg, image/jpg, image/webp, image/gif, image/bmp",
+  maxSizeMB = 5,
+  previewUrl,
+}: ImageUploadProps) => {
+  const [preview, setPreview] = useState<string | null>(previewUrl || null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (file: File | null) => {
+    if (!file) return;
+
+    // ファイルサイズチェック
+    if (file.size > maxSizeMB * 1024 * 1024) {
+      alert(`ファイルサイズは${maxSizeMB}MB以下にしてください`);
+      return;
+    }
+
+    // ファイル形式チェック
+    const acceptedTypes = acceptedFormats.split(", ");
+    if (!acceptedTypes.includes(file.type)) {
+      alert("サポートされていないファイル形式です");
+      return;
+    }
+
+    // プレビュー生成
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setPreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+
+    onImageSelect(file);
+  };
+
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      handleFileChange(files[0]);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      handleFileChange(files[0]);
+    }
+  };
+
+  return (
+    <div className={styles["upload-container"]}>
+      <span className={styles["upload-label"]}>サムネイル</span>
+      <button
+        type="button"
+        className={styles["upload-area"]}
+        onClick={handleClick}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        data-dragging={isDragging ? "true" : "false"}
+        data-has-image={preview ? "true" : "false"}
+        aria-label="画像をアップロード"
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={acceptedFormats}
+          onChange={handleInputChange}
+          className={styles["file-input"]}
+          tabIndex={-1}
+        />
+        {preview ? (
+          <img
+            src={preview}
+            alt="アップロードされた画像のプレビュー"
+            className={styles["preview-image"]}
+          />
+        ) : (
+          <CloudUploadRoundedIcon
+            style={{
+              fontSize: 128,
+              color: isDragging ? "var(--primary-color)" : "#999",
+            }}
+          />
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default ImageUpload;

--- a/src/features/WorkForm/index.tsx
+++ b/src/features/WorkForm/index.tsx
@@ -1,0 +1,17 @@
+import ImageUpload from "./ImageUpload";
+
+import Paper from "@/shared/ui/Paper";
+
+const WorkForm = () => {
+  return (
+    <Paper>
+      <ImageUpload
+        onImageSelect={(file: File) => {
+          console.log("Selected file:", file);
+        }}
+      />
+    </Paper>
+  );
+};
+
+export default WorkForm;

--- a/src/pages/EditPage/index.tsx
+++ b/src/pages/EditPage/index.tsx
@@ -2,6 +2,7 @@ import styles from "./index.module.css";
 
 import Header from "@/features/Header";
 import MarkdownEditor from "@/features/MarkdownEditor";
+import WorkForm from "@/features/WorkForm";
 
 const EditPage = () => {
   return (
@@ -10,6 +11,7 @@ const EditPage = () => {
       <main className={styles["main-wrapper"]}>
         <h1>EditPage</h1>
         <MarkdownEditor />
+        <WorkForm />
       </main>
     </>
   );


### PR DESCRIPTION
### サムネイルアップロードコンポーネントの作成
- UI
- ドラッグ&ドロップ
- プレビュー

<img width="991" height="599" alt="image" src="https://github.com/user-attachments/assets/7534ac09-30e7-4713-b21e-ba93878d6770" />

---
#### 未実装
- 対応ファイル制限
- ファイルサイズ制限
- 保存処理