### PR TITLE
[fix] #80 日時の表示ズレ修正とフォーマットの統一

### DIFF
--- a/src/features/WorkDetail/index.tsx
+++ b/src/features/WorkDetail/index.tsx
@@ -11,6 +11,12 @@ type WorkDetailProps = {
   workID: string;
 };
 
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const pad = (num: number) => num.toString().padStart(2, "0");
+  return ` ${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
 const WorkDetail = ({ workID }: WorkDetailProps) => {
   const { data, error } = useWorkDetail({ id: workID });
 
@@ -40,28 +46,12 @@ const WorkDetail = ({ workID }: WorkDetailProps) => {
         </div>
         <div className={styles["info-wrapper"]}>
           <p className={styles["work-postdate"]}>
-            投稿日：
-            {new Date(data.created_at).getFullYear() +
-              "/" +
-              (new Date(data.created_at).getMonth() + 1) +
-              "/" +
-              new Date(data.created_at).getDate() +
-              " " +
-              new Date(data.created_at).getHours() +
-              ":" +
-              new Date(data.created_at).getMinutes()}
+            投稿日
+            {formatDate(data.created_at)}
           </p>
           <p className={styles["work-postdate"]}>
-            更新日：
-            {new Date(data.updated_at).getFullYear() +
-              "/" +
-              (new Date(data.updated_at).getMonth() + 1) +
-              "/" +
-              new Date(data.updated_at).getDate() +
-              " " +
-              new Date(data.updated_at).getHours() +
-              ":" +
-              new Date(data.updated_at).getMinutes()}
+            更新日
+            {formatDate(data.updated_at)}
           </p>
         </div>
       </div>

--- a/src/features/WorkDetail/index.tsx
+++ b/src/features/WorkDetail/index.tsx
@@ -6,15 +6,10 @@ import styles from "./index.module.css";
 import Avatar from "@/shared/ui/Avatar";
 import Batch from "@/shared/ui/Batch";
 import Paper from "@/shared/ui/Paper";
+import { formatDateTime } from "@/util/formatDateTime";
 
 type WorkDetailProps = {
   workID: string;
-};
-
-const formatDate = (dateString: string) => {
-  const date = new Date(dateString);
-  const pad = (num: number) => num.toString().padStart(2, "0");
-  return ` ${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
 
 const WorkDetail = ({ workID }: WorkDetailProps) => {
@@ -46,12 +41,10 @@ const WorkDetail = ({ workID }: WorkDetailProps) => {
         </div>
         <div className={styles["info-wrapper"]}>
           <p className={styles["work-postdate"]}>
-            投稿日
-            {formatDate(data.created_at)}
+            投稿日：{formatDateTime(data.created_at)}
           </p>
           <p className={styles["work-postdate"]}>
-            更新日
-            {formatDate(data.updated_at)}
+            更新日：{formatDateTime(data.updated_at)}
           </p>
         </div>
       </div>

--- a/src/features/WorkDetail/index.tsx
+++ b/src/features/WorkDetail/index.tsx
@@ -41,10 +41,10 @@ const WorkDetail = ({ workID }: WorkDetailProps) => {
         </div>
         <div className={styles["info-wrapper"]}>
           <p className={styles["work-postdate"]}>
-            投稿日：{formatDateTime(data.created_at)}
+            投稿日 {formatDateTime(data.created_at)}
           </p>
           <p className={styles["work-postdate"]}>
-            更新日：{formatDateTime(data.updated_at)}
+            更新日 {formatDateTime(data.updated_at)}
           </p>
         </div>
       </div>

--- a/src/features/WorkDetail/index.tsx
+++ b/src/features/WorkDetail/index.tsx
@@ -43,7 +43,7 @@ const WorkDetail = ({ workID }: WorkDetailProps) => {
             投稿日：
             {new Date(data.created_at).getFullYear() +
               "/" +
-              new Date(data.created_at).getMonth() +
+              (new Date(data.created_at).getMonth() + 1) +
               "/" +
               new Date(data.created_at).getDate() +
               " " +
@@ -55,7 +55,7 @@ const WorkDetail = ({ workID }: WorkDetailProps) => {
             更新日：
             {new Date(data.updated_at).getFullYear() +
               "/" +
-              new Date(data.updated_at).getMonth() +
+              (new Date(data.updated_at).getMonth() + 1) +
               "/" +
               new Date(data.updated_at).getDate() +
               " " +

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -2,6 +2,8 @@ import Avatar from "../Avatar";
 import Batch from "../Batch";
 import styles from "./index.module.css";
 
+import { formatDateTime } from "@/util/formatDateTime";
+
 import type { Tag } from "@/shared/types/work";
 
 type CardProps = {
@@ -23,8 +25,6 @@ const Card = ({
   avatarURL = "./comingSoonLugia.webp",
   imageURL = "./comingSoonHo-Oh.webp",
 }: CardProps) => {
-  const pad = (num: number) => num.toString().padStart(2, "0");
-
   return (
     <div className={styles["card-wrapper"]}>
       <div className={styles["card-image-wrapper"]}>
@@ -37,15 +37,7 @@ const Card = ({
           <div className={styles["info-wrapper"]}>
             <p className={styles["card-username"]}>{username}</p>
             <p className={styles["card-postdate"]}>
-              {postDate.getFullYear() +
-                "/" +
-                pad(postDate.getMonth() + 1) +
-                "/" +
-                pad(postDate.getDate()) +
-                " " +
-                pad(postDate.getHours()) +
-                ":" +
-                pad(postDate.getMinutes())}
+              {formatDateTime(postDate)}
             </p>
           </div>
         </div>

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -37,7 +37,7 @@ const Card = ({
           <div className={styles["info-wrapper"]}>
             <p className={styles["card-username"]}>{username}</p>
             <p className={styles["card-postdate"]}>
-              {pad(postDate.getFullYear()) +
+              {postDate.getFullYear() +
                 "/" +
                 pad(postDate.getMonth() + 1) +
                 "/" +

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -37,7 +37,7 @@ const Card = ({
             <p className={styles["card-postdate"]}>
               {postDate.getFullYear() +
                 "/" +
-                postDate.getMonth() +
+                (postDate.getMonth() + 1) +
                 "/" +
                 postDate.getDate()}
             </p>

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -23,6 +23,8 @@ const Card = ({
   avatarURL = "./comingSoonLugia.webp",
   imageURL = "./comingSoonHo-Oh.webp",
 }: CardProps) => {
+  const pad = (num: number) => num.toString().padStart(2, "0");
+
   return (
     <div className={styles["card-wrapper"]}>
       <div className={styles["card-image-wrapper"]}>
@@ -35,11 +37,15 @@ const Card = ({
           <div className={styles["info-wrapper"]}>
             <p className={styles["card-username"]}>{username}</p>
             <p className={styles["card-postdate"]}>
-              {postDate.getFullYear() +
+              {pad(postDate.getFullYear()) +
                 "/" +
-                (postDate.getMonth() + 1) +
+                pad(postDate.getMonth() + 1) +
                 "/" +
-                postDate.getDate()}
+                pad(postDate.getDate()) +
+                " " +
+                pad(postDate.getHours()) +
+                ":" +
+                pad(postDate.getMinutes())}
             </p>
           </div>
         </div>

--- a/src/util/formatDateTime.ts
+++ b/src/util/formatDateTime.ts
@@ -1,0 +1,8 @@
+export const formatDateTime = (dateString: string | Date): string => {
+  const date = new Date(dateString);
+  const pad = (value: number): string => value.toString().padStart(2, "0");
+
+  return `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(
+    date.getDate(),
+  )} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};


### PR DESCRIPTION
- Card及びWorkDetailの投稿日・更新日の月のズレを修正
- 各日時データの表示フォーマットをYYYY/MM/DD HH:MMに統一

Close #80   